### PR TITLE
Add ability to remove picture when voted on

### DIFF
--- a/app/models/picture.rb
+++ b/app/models/picture.rb
@@ -3,7 +3,7 @@
 class Picture < ApplicationRecord
   belongs_to :celebrity
   has_one :picture_point, foreign_key: :winning_picture_id
-  has_many :votes, foreign_key: :chosen_picture_id
+  has_many :votes, foreign_key: :chosen_picture_id, dependent: :destroy
   has_attached_file :attachment, styles: { voting: '300x', leaderboard: '500x' }
   validates_attachment_content_type :attachment, content_type: %r{\Aimage\/.*\z}
 

--- a/db/migrate/20180523190352_add_cascading_delete_to_votes_foreign_keys.rb
+++ b/db/migrate/20180523190352_add_cascading_delete_to_votes_foreign_keys.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddCascadingDeleteToVotesForeignKeys < ActiveRecord::Migration[5.2]
+  def change
+    remove_foreign_key :votes, column: :left_picture_id
+    remove_foreign_key :votes, column: :right_picture_id
+
+    add_foreign_key :votes, :pictures, column: :left_picture_id,
+                    on_delete: :cascade
+    add_foreign_key :votes, :pictures, column: :right_picture_id, 
+                    on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_03_18_175322) do
+ActiveRecord::Schema.define(version: 2018_05_23_190352) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -49,8 +49,8 @@ ActiveRecord::Schema.define(version: 2018_03_18_175322) do
   add_foreign_key "pictures", "celebrities"
   add_foreign_key "votes", "celebrities"
   add_foreign_key "votes", "pictures", column: "chosen_picture_id"
-  add_foreign_key "votes", "pictures", column: "left_picture_id"
-  add_foreign_key "votes", "pictures", column: "right_picture_id"
+  add_foreign_key "votes", "pictures", column: "left_picture_id", on_delete: :cascade
+  add_foreign_key "votes", "pictures", column: "right_picture_id", on_delete: :cascade
 
   create_view "picture_points",  sql_definition: <<-SQL
       SELECT point_results.winning_picture_id,

--- a/spec/models/picture_spec.rb
+++ b/spec/models/picture_spec.rb
@@ -6,17 +6,18 @@ RSpec.describe Picture, type: :model do
   let(:celebrity) { FactoryBot.create(:celebrity, name: 'Taylor Swift') }
 
   it 'can be deleted when it has votes' do
-    FactoryBot.create_list(:picture, 1, celebrity: celebrity)
-    picture = Picture.first
+    FactoryBot.create_list(:picture, 2, celebrity: celebrity)
+    left = Picture.first
+    right = Picture.last
     vote = Vote.new
 
     vote.celebrity = celebrity
-    vote.left_picture_id = picture.id
-    vote.right_picture_id = picture.id
-    vote.chosen_picture_id = picture.id
+    vote.left_picture_id = left.id
+    vote.right_picture_id = right.id
+    vote.chosen_picture_id = left.id
     vote.save!
 
-    expect { picture.destroy }.not_to raise_error
-    expect(Picture.count).to eq 0
+    expect { left.destroy }.not_to raise_error
+    expect(Picture.count).to eq 1
   end
 end

--- a/spec/models/picture_spec.rb
+++ b/spec/models/picture_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Picture, type: :model do
+  let(:celebrity) { FactoryBot.create(:celebrity, name: 'Taylor Swift') }
+
+  it 'can be deleted when it has votes' do
+    FactoryBot.create_list(:picture, 1, celebrity: celebrity)
+    picture = Picture.first
+    vote = Vote.new
+
+    vote.celebrity = celebrity
+    vote.left_picture_id = picture.id
+    vote.right_picture_id = picture.id
+    vote.chosen_picture_id = picture.id
+    vote.save!
+
+    expect { picture.destroy }.not_to raise_error
+    expect(Picture.count).to eq 0
+  end
+end

--- a/spec/models/picture_spec.rb
+++ b/spec/models/picture_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Picture, type: :model do
   let(:celebrity) { FactoryBot.create(:celebrity, name: 'Taylor Swift') }
 
-  it 'can be deleted when it has votes' do
+  it 'can be deleted when it is voted on but not chosen' do
     FactoryBot.create_list(:picture, 2, celebrity: celebrity)
     left = Picture.first
     right = Picture.last
@@ -14,7 +14,7 @@ RSpec.describe Picture, type: :model do
     vote.celebrity = celebrity
     vote.left_picture_id = left.id
     vote.right_picture_id = right.id
-    vote.chosen_picture_id = left.id
+    vote.chosen_picture_id = right.id
     vote.save!
 
     expect { left.destroy }.not_to raise_error


### PR DESCRIPTION
This change adds the ability to remove a picture when it has been voted on. Previously, all the votes needed to be removed from the picture before it was able to be destroyed.